### PR TITLE
#2 Change reconcile loop object creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,25 @@ spec:
 container requests and limits, postgres version and the port used to connect to the pod
 
 in `test/` dir you'll find a read me file explaining how to test this operator in kubenretes.
+
+
+### Problem
+There is a bug currently in the operator while creating all objects for postgres deployment (configMap, Secret, Service and Deployment). The problem is that reconcile loop will create only configMap as it will return result{}, nil (empty result which will not reconcile):
+```
+{"level":"INFO","time":"2023-02-21T22:40:50.492Z","message":"Start reconcile","namespace":"pgdep-test"}
+{"level":"INFO","time":"2023-02-21T22:40:50.492Z","message":"create object","namespace":"pgdep-test","object":"pg-cm"}
+{"level":"INFO","time":"2023-02-21T22:40:50.537Z","message":"create object","namespace":"pgdep-test","object":"pg-secret"}
+{"level":"INFO","time":"2023-02-21T22:40:50.544Z","message":"create object","namespace":"pgdep-test","object":"pgdeployment"}
+{"level":"INFO","time":"2023-02-21T22:40:50.554Z","message":"create object","namespace":"pgdep-test","object":"pg-service"}
+{"level":"INFO","time":"2023-02-21T22:40:50.597Z","message":"Start reconcile","namespace":"pgdep-test"}
+{"level":"INFO","time":"2023-02-21T22:40:50.597Z","message":"create object","namespace":"pgdep-test","object":"pg-cm"}
+{"level":"INFO","time":"2023-02-21T22:40:50.630Z","message":"Start reconcile","namespace":"pgdep-test"}
+{"level":"INFO","time":"2023-02-21T22:40:50.630Z","message":"create object","namespace":"pgdep-test","object":"pg-cm"}
+{"level":"INFO","time":"2023-02-21T22:40:50.669Z","message":"Start reconcile","namespace":"pgdep-test"}
+{"level":"INFO","time":"2023-02-21T22:40:50.670Z","message":"create object","namespace":"pgdep-test","object":"pg-cm"}
+{"level":"INFO","time":"2023-02-21T22:40:51.844Z","message":"Start reconcile","namespace":"pgdep-test"}
+{"level":"INFO","time":"2023-02-21T22:40:51.844Z","message":"create object","namespace":"pgdep-test","object":"pg-cm"}
+```
+
+### Solution
+Recreate each object in another function, move specs to reconciler (controller) and restructure the order of object creation in reconcile loop 

--- a/README.md
+++ b/README.md
@@ -20,24 +20,3 @@ container requests and limits, postgres version and the port used to connect to 
 
 in `test/` dir you'll find a read me file explaining how to test this operator in kubenretes.
 
-
-### Problem
-There is a bug currently in the operator while creating all objects for postgres deployment (configMap, Secret, Service and Deployment). The problem is that reconcile loop will create only configMap as it will return result{}, nil (empty result which will not reconcile):
-```
-{"level":"INFO","time":"2023-02-21T22:40:50.492Z","message":"Start reconcile","namespace":"pgdep-test"}
-{"level":"INFO","time":"2023-02-21T22:40:50.492Z","message":"create object","namespace":"pgdep-test","object":"pg-cm"}
-{"level":"INFO","time":"2023-02-21T22:40:50.537Z","message":"create object","namespace":"pgdep-test","object":"pg-secret"}
-{"level":"INFO","time":"2023-02-21T22:40:50.544Z","message":"create object","namespace":"pgdep-test","object":"pgdeployment"}
-{"level":"INFO","time":"2023-02-21T22:40:50.554Z","message":"create object","namespace":"pgdep-test","object":"pg-service"}
-{"level":"INFO","time":"2023-02-21T22:40:50.597Z","message":"Start reconcile","namespace":"pgdep-test"}
-{"level":"INFO","time":"2023-02-21T22:40:50.597Z","message":"create object","namespace":"pgdep-test","object":"pg-cm"}
-{"level":"INFO","time":"2023-02-21T22:40:50.630Z","message":"Start reconcile","namespace":"pgdep-test"}
-{"level":"INFO","time":"2023-02-21T22:40:50.630Z","message":"create object","namespace":"pgdep-test","object":"pg-cm"}
-{"level":"INFO","time":"2023-02-21T22:40:50.669Z","message":"Start reconcile","namespace":"pgdep-test"}
-{"level":"INFO","time":"2023-02-21T22:40:50.670Z","message":"create object","namespace":"pgdep-test","object":"pg-cm"}
-{"level":"INFO","time":"2023-02-21T22:40:51.844Z","message":"Start reconcile","namespace":"pgdep-test"}
-{"level":"INFO","time":"2023-02-21T22:40:51.844Z","message":"create object","namespace":"pgdep-test","object":"pg-cm"}
-```
-
-### Solution
-Recreate each object in another function, move specs to reconciler (controller) and restructure the order of object creation in reconcile loop 

--- a/controllers/objects_builder.go
+++ b/controllers/objects_builder.go
@@ -1,34 +1,20 @@
-package v1alpha1
+package controllers
 
 import (
 	"math/rand"
 
+	"github.com/nadavbm/pgdeployer/api/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const numOfReplicas = 1
 const letterBytes = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@#$&*"
 
-// ConstructObjectsFromSpecifications construct a slice of kubernetes object interfaces from specifications
-func (pd *PgDeployer) ConstructObjectsFromSpecifications(ns string) []client.Object {
-	var objects []client.Object
-
-	cm := buildConfigMap(ns, pd)
-	secret := buildSecret(ns, pd)
-	deploy := buildDeployment(ns, pd)
-	svc := buildService(ns, pd)
-
-	objects = append(objects, cm, secret, deploy, svc)
-
-	return objects
-}
-
 // buildDeployment creates a kubernetes deployment specification
-func buildDeployment(ns string, pgDeploy *PgDeployer) *appsv1.Deployment {
+func buildDeployment(ns string, pgDeploy *v1alpha1.PgDeployer) *appsv1.Deployment {
 	component := "pgdeployment"
 	replicas := int32(numOfReplicas)
 	return &appsv1.Deployment{
@@ -80,7 +66,7 @@ func buildDeployment(ns string, pgDeploy *PgDeployer) *appsv1.Deployment {
 }
 
 // buildConfigMap will build a kubernetes config map for postgres
-func buildConfigMap(ns string, pgDeploy *PgDeployer) *v1.ConfigMap {
+func buildConfigMap(ns string, pgDeploy *v1alpha1.PgDeployer) *v1.ConfigMap {
 	component := "pg-cm"
 	return &v1.ConfigMap{
 		TypeMeta: metav1.TypeMeta{
@@ -96,7 +82,7 @@ func buildConfigMap(ns string, pgDeploy *PgDeployer) *v1.ConfigMap {
 }
 
 // buildSecret kubenretes secret for postgres (password generated on the fly and to get it use kubectl get sercet secret-name -o yaml etc.)
-func buildSecret(ns string, pgDeploy *PgDeployer) *v1.Secret {
+func buildSecret(ns string, pgDeploy *v1alpha1.PgDeployer) *v1.Secret {
 	component := "pg-secret"
 	return &v1.Secret{
 		TypeMeta: metav1.TypeMeta{
@@ -109,7 +95,7 @@ func buildSecret(ns string, pgDeploy *PgDeployer) *v1.Secret {
 }
 
 // buildService in kubernetes with pgDeploy port
-func buildService(ns string, pgDeploy *PgDeployer) *v1.Service {
+func buildService(ns string, pgDeploy *v1alpha1.PgDeployer) *v1.Service {
 	component := "pg-service"
 	return &v1.Service{
 		TypeMeta: metav1.TypeMeta{
@@ -147,7 +133,7 @@ func getEnvVarSecretSource(envName, name, secret string) v1.EnvVar {
 	}
 }
 
-func buildMetadata(ns, component string, pgDeploy *PgDeployer) metav1.ObjectMeta {
+func buildMetadata(ns, component string, pgDeploy *v1alpha1.PgDeployer) metav1.ObjectMeta {
 	controller := true
 	return metav1.ObjectMeta{
 		Name:      component,

--- a/controllers/specs_test.go
+++ b/controllers/specs_test.go
@@ -1,16 +1,17 @@
-package v1alpha1
+package controllers
 
 import (
 	"testing"
 
+	"github.com/nadavbm/pgdeployer/api/v1alpha1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 func TestKubernetesSpecifications(t *testing.T) {
-	var pgDeploy PgDeployer
+	var pgDeploy v1alpha1.PgDeployer
 
-	deploy := PgDeployerSpec{
+	deploy := v1alpha1.PgDeployerSpec{
 		PgVersion:     "14",
 		ContainerPort: 5432,
 		CpuRequest:    "500m",
@@ -63,7 +64,7 @@ func TestKubernetesSpecifications(t *testing.T) {
 		t.Errorf("expected service port to be %d, instead got %d", pgDeploy.Spec.ContainerPort, service.Spec.Ports[0].Port)
 	}
 
-	deploy = PgDeployerSpec{
+	deploy = v1alpha1.PgDeployerSpec{
 		PgVersion:     "13",
 		ContainerPort: 5433,
 		CpuRequest:    "100m",

--- a/test/pgdeployer.yaml
+++ b/test/pgdeployer.yaml
@@ -126,7 +126,7 @@ spec:
       serviceAccountName: pgdeploy-operator
       containers:
         - name: pgdeploy-operator
-          image: nadavbm/pgdeploy-operator:v0.0.9
+          image: nadavbm/pgdeploy-operator:v0.1.0
           command:
             - /pgdeploy-operator
           imagePullPolicy: Always


### PR DESCRIPTION
### Problem
There is a bug currently in the operator while creating all objects for postgres deployment (configMap, Secret, Service and Deployment). The problem is that reconcile loop will create only configMap as it will return result{}, nil (empty result which will not reconcile):
```
{"level":"INFO","time":"2023-02-21T22:40:50.492Z","message":"Start reconcile","namespace":"pgdep-test"}
{"level":"INFO","time":"2023-02-21T22:40:50.492Z","message":"create object","namespace":"pgdep-test","object":"pg-cm"}
{"level":"INFO","time":"2023-02-21T22:40:50.537Z","message":"create object","namespace":"pgdep-test","object":"pg-secret"}
{"level":"INFO","time":"2023-02-21T22:40:50.544Z","message":"create object","namespace":"pgdep-test","object":"pgdeployment"}
{"level":"INFO","time":"2023-02-21T22:40:50.554Z","message":"create object","namespace":"pgdep-test","object":"pg-service"}
{"level":"INFO","time":"2023-02-21T22:40:50.597Z","message":"Start reconcile","namespace":"pgdep-test"}
{"level":"INFO","time":"2023-02-21T22:40:50.597Z","message":"create object","namespace":"pgdep-test","object":"pg-cm"}
{"level":"INFO","time":"2023-02-21T22:40:50.630Z","message":"Start reconcile","namespace":"pgdep-test"}
{"level":"INFO","time":"2023-02-21T22:40:50.630Z","message":"create object","namespace":"pgdep-test","object":"pg-cm"}
{"level":"INFO","time":"2023-02-21T22:40:50.669Z","message":"Start reconcile","namespace":"pgdep-test"}
{"level":"INFO","time":"2023-02-21T22:40:50.670Z","message":"create object","namespace":"pgdep-test","object":"pg-cm"}
{"level":"INFO","time":"2023-02-21T22:40:51.844Z","message":"Start reconcile","namespace":"pgdep-test"}
{"level":"INFO","time":"2023-02-21T22:40:51.844Z","message":"create object","namespace":"pgdep-test","object":"pg-cm"}
```

### Solution
Recreate each object in another function, move specs to reconciler (controller) and restructure the order of object creation in reconcile loop 